### PR TITLE
Fix issue related to radius for MATLAB Multiscale Fuzzy Entropy

### DIFF
--- a/matlab/Ent_MS_Plus.m
+++ b/matlab/Ent_MS_Plus.m
@@ -170,7 +170,6 @@ assert(control,'The user must introduce a step for the fuzzy exponential functio
 N = length(series);
 phi = zeros(1,2);
 % Value of 'r' in case of not normalized time series:
-r = r*std(series);
 
 for j = 1:2
     m = dim+j-1; % 'm' is the embbeding dimension used each iteration


### PR DESCRIPTION
Hi, the radius times std has been occurred two times for Multiscale Fuzzy Entropy.
First, at the beginning: https://github.com/Nonlinear-Analysis-Core/NONANLibrary/blob/0bf6a6fb84e1bea31c2ede2664dff3fcc055d310/matlab/Ent_MS_Plus.m#L33

Second, inside the Fuzzy_Ent function: https://github.com/Nonlinear-Analysis-Core/NONANLibrary/blob/0bf6a6fb84e1bea31c2ede2664dff3fcc055d310/matlab/Ent_MS_Plus.m#L173